### PR TITLE
Fix bug in truecolor background support. 

### DIFF
--- a/examples/dvtm/dvtm.c
+++ b/examples/dvtm/dvtm.c
@@ -515,10 +515,10 @@ vt_color_get(Term *t, int fg, int bg)
 	if (bg < 0)
 		bg = defaultbg;
 	else if (bg > COLORS) {
-		r = TRUERED(bg)   / 32;
-		g = TRUEGREEN(bg) / 32;
-		b = TRUEBLUE(bg)  / 64;
-		fg = colour_find_rgb(r, g, b);
+		r = TRUERED(bg);
+		g = TRUEGREEN(bg);
+		b = TRUEBLUE(bg);
+		bg = colour_find_rgb(r, g, b);
 	}
 
 	if (!color2palette)

--- a/examples/svt/svt.c
+++ b/examples/svt/svt.c
@@ -207,7 +207,7 @@ vt_color_get(Term *t, int fg, int bg)
 		r = TRUERED(bg);
 		g = TRUEGREEN(bg);
 		b = TRUEBLUE(bg);
-		fg = colour_find_rgb(r, g, b);
+		bg = colour_find_rgb(r, g, b);
 	}
 
 	if (!color2palette)


### PR DESCRIPTION
It is still, however, using only the 6cube approximation of the specified truecolor. Here's a good shell command to run before and after for validation.

    printf "\x1b[48;2;255;100;0m\x1b[30m ORANGE \x1b[0m\n"