### PR TITLE
Conveniencefunctions

### DIFF
--- a/examples/st/st.c
+++ b/examples/st/st.c
@@ -182,6 +182,9 @@ static void xsetenv(void);
 static void xseturgency(int);
 static int evcol(XEvent *);
 static int evrow(XEvent *);
+static void *xmalloc(size_t);
+static void *xrealloc(void *, size_t);
+static char *xstrdup(char *);
 
 static void expose(XEvent *);
 static void visibility(XEvent *);
@@ -200,6 +203,7 @@ static int match(uint, uint);
 
 static void run(void);
 static void usage(void);
+static void die(const char *, ...);
 
 static void (*handler[LASTEvent])(XEvent *) = {
 	[KeyPress] = kpress,
@@ -263,6 +267,46 @@ static char *opt_name  = NULL;
 static char *opt_title = NULL;
 
 static int oldbutton = 3; /* button event on startup: 3 = release */
+
+void
+die(const char *errstr, ...)
+{
+	va_list ap;
+
+	va_start(ap, errstr);
+	vfprintf(stderr, errstr, ap);
+	va_end(ap);
+	exit(1);
+}
+
+void *
+xmalloc(size_t len)
+{
+	void *p;
+
+	if (!(p = malloc(len)))
+		die("malloc: %s\n", strerror(errno));
+
+	return p;
+}
+
+void *
+xrealloc(void *p, size_t len)
+{
+	if ((p = realloc(p, len)) == NULL)
+		die("realloc: %s\n", strerror(errno));
+
+	return p;
+}
+
+char *
+xstrdup(char *s)
+{
+	if ((s = strdup(s)) == NULL)
+		die("strdup: %s\n", strerror(errno));
+
+	return s;
+}
 
 void
 clipcopy(const Arg *dummy)

--- a/libst.c
+++ b/libst.c
@@ -80,6 +80,7 @@ typedef unsigned char uchar;
 typedef unsigned int uint;
 
 static void execsh(char *, char **);
+static void die(const char *, ...);
 static void ttywriteraw(Term *term, const char *, size_t);
 
 static void csidump(Term *);
@@ -135,6 +136,9 @@ static char *base64dec(const char *);
 static char base64dec_getc(const char **);
 
 static ssize_t xwrite(int, const char *, size_t);
+static void *xmalloc(size_t);
+static void *xrealloc(void *, size_t);
+static char *xstrdup(char *);
 
 static uchar utfbyte[UTF_SIZ + 1] = {0x80,    0, 0xC0, 0xE0, 0xF0};
 static uchar utfmask[UTF_SIZ + 1] = {0xC0, 0x80, 0xE0, 0xF0, 0xF8};

--- a/libst.h
+++ b/libst.h
@@ -185,8 +185,6 @@ struct Term {
 	STREscape strescseq;
 };
 
-void die(const char *, ...);
-
 void tprintscreen(Term *);
 void tsendbreak(Term *);
 void ttoggleprinter(Term *);
@@ -207,7 +205,3 @@ void ttywrite(Term *, const char *, size_t, int);
 void resettitle(Term *);
 
 size_t utf8encode(Rune, char *);
-
-void *xmalloc(size_t);
-void *xrealloc(void *, size_t);
-char *xstrdup(char *);


### PR DESCRIPTION
Remove convenience functions die(), xmalloc(), xrealloc(), and xstrdup() from libst.h. Move the declarations into libst.c and add the functions into the st.c example code. 